### PR TITLE
Issue fixed where If the previous selected donation item had locked p…

### DIFF
--- a/src/donation-form/src/index.ts
+++ b/src/donation-form/src/index.ts
@@ -424,6 +424,7 @@ class DonationForm extends LitElement {
       if (this._givingType === GivingType.Donation) {
         if (option.fund?.donationPriceHandles?.length) {
           this._otherAmountLocked = false;
+          this._otherAmount = undefined;
           return;
         }
       } else {


### PR DESCRIPTION
Issue fixed: If the previously selected donation item had a locked price and the selected one did not, it will now remove the price and leave the field empty.